### PR TITLE
Add inline doc example for installing an ifix from a directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 install:
 - sudo add-apt-repository ppa:deadsnakes/ppa --yes
 - sudo apt-get --yes --force-yes install python3-venv
-- pip install ansible
+- pip install ansible==2.9
 - pip install flake8
 - pip3 install ansible-doc-extractor
 - pip install sphinx

--- a/plugins/modules/updateios.py
+++ b/plugins/modules/updateios.py
@@ -101,6 +101,13 @@ EXAMPLES = r'''
     action: install
     filesets: ILMT-TAD4D-agent
     device: /dev/cd1
+
+- name: Install an ifix copied in VIOS home directory
+  updateios:
+    action: update
+    device: /home/padmin/IV92895s7a
+    install_new: yes
+    accept_licenses: yes
 '''
 
 RETURN = r'''


### PR DESCRIPTION
This PR contains:
- updateios: document an example for installing an ifix from a directory
- travis build limitation to Ansible==2.9 (doc-extractor issue with Ansible 2.10)
